### PR TITLE
set useTabs to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   printWidth: 100,
   semi: true,
+  useTabs: true,
   singleQuote: true,
   trailingComma: "es5",
   jsxSingleQuote: true,


### PR DESCRIPTION
I noticed we are using spaces by indentation by default and have recently come across some fairly convincing arguments to use tabs (related to accessibility) e.g.: https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/