### PR TITLE
Add importOrder option in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  importOrderParserPlugins: ["typescript", "decorators-legacy"],
   printWidth: 100,
   semi: true,
   singleQuote: true,


### PR DESCRIPTION
Given I want to use [this plugin](https://github.com/trivago/prettier-plugin-sort-imports#importorderparserplugins), I also need to add this option to the Prettier config to allow for some parsing of decorators. Looks like the Sort Import plugin modifies the AST and requires this extra configuration.

I don't believe this should affect folks not using the Sort Import plugin, but perhaps that is something we want to bake into this configuration.